### PR TITLE
add compiler flag -Wno-error=incompatible-function-pointer-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Requirements:
 ```bash
 cd src/
 make clean
-CFLAGS='-std=gnu89 -Wno-return-type -Wno-implicit-function-declaration' make LOADLIBES='-ll'
+CFLAGS='-std=gnu89 -Wno-return-type -Wno-implicit-function-declaration -Wno-error=incompatible-function-pointer-types' make LOADLIBES='-ll'
 make install
 ```
 


### PR DESCRIPTION
On Apple M1, macOS Sonoma 14.3.1, Apple clang version 15.0.0

`CFLAGS='-std=gnu89 -Wno-return-type -Wno-implicit-function-declaration' make LOADLIBES='-ll' failed with the following error message:

```
genwd.c:49:48: error: incompatible function pointer types passing 'int (gk_word *, gk_word *)' to parameter of type 'int (* _Nonnull)(const void *, const void *)' [-Wincompatible-function-pointer-types]
        qsort(gkforms,formcnt,sizeof * gkforms,CompGkForms);    
                                               ^~~~~~~~~~~
```

Apparently the warning "incompatible function pointer types" [was upgraded to a fatal error](https://reviews.llvm.org/D131351) in Aug. 2022. This PR adds the compiler flag -Wno-error=incompatible-function-pointer-types that reverts the error to a warning.

Tested locally, project now builds and runs successfully.