### PR TITLE
Loose case mode (-S) match on upper case Greek dictionary entries

### DIFF
--- a/src/anal/checkstring.c
+++ b/src/anal/checkstring.c
@@ -365,6 +365,29 @@ checkstring3(gk_word *Gkword)
     }
     Xstrncpy(string,saveword,MAXWORDSIZE);
   }
+  /* NEW CODE: Try capitalizing a lowercase Greek word when strict case is off */
+  else if( cur_lang() == GREEK && !rval && !(prntflags_of(Gkword)&STRICT_CASE) ) {
+    char capword[MAXWORDSIZE];
+
+    /* Save current word and make capitalized version */
+    Xstrncpy(capword, workword_of(Gkword), MAXWORDSIZE);
+
+    /* Only proceed if word doesn't already start with asterisk */
+    if(capword[0] != BETA_UCASE_MARKER) {
+      /* Move all characters right by 1 and add asterisk */
+      memmove(capword + 1, capword, strlen(capword) + 1);
+      capword[0] = BETA_UCASE_MARKER;
+
+      set_workword(Gkword, capword);
+      if((rval = checkstring4(Gkword)) > 0) {
+        set_workword(Gkword, saveword);
+        return(rval);
+      }
+    }
+
+    /* Restore original word */
+    Xstrncpy(string, saveword, MAXWORDSIZE);
+  }
 
   if( Has_apostr(workword_of(Gkword)) ) {
     if( (rval+=checkapostr(Gkword))) {

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -602,6 +602,14 @@
   },
   {
     "input": "kentaurikw=s",
+    "expected": ""
+  },
+  {
+    "input": "*kentaurikw=s",
+    "expected": "*kentaurikw=s\n<NL>N *kentauriko/s  adverbial\t\t\tos_h_on</NL>\n"
+  },
+  {
+    "input": "kentaurikw=s",
     "opts": [
       "-S"
     ],

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -599,5 +599,43 @@
       "-S"
     ],
     "expected": "appellantur\n<NL>V appello  pres ind pass 3rd pl\t\t\tconj1,are_vb</NL><NL>V appello#1  pres subj pass 3rd pl\t\t\tconj3</NL>\n"
+  },
+  {
+    "input": "kentaurikw=s",
+    "opts": [
+      "-S"
+    ],
+    "expected": "kentaurikw=s\n<NL>N *kentaurikw=s,*kentauriko/s  adverbial\t\t\tos_h_on</NL>\n"
+  },
+  {
+    "input": "*kentaurikw=s",
+    "opts": [
+      "-S"
+    ],
+    "expected": "*kentaurikw=s\n<NL>N *kentauriko/s  adverbial\t\t\tos_h_on</NL>\n"
+  },
+  {
+    "input": "kentaurikw=s",
+    "opts": [
+      "-S",
+      "-n"
+    ],
+    "expected": "kentaurikw=s\n<NL>N *kentaurikw=s,*kentauriko/s  adverbial\t\t\tos_h_on</NL><NL>N *kentaurikw/s,*kentauriko/s  masc acc pl\tdoric\t\tos_h_on</NL>\n"
+  },
+  {
+    "input": "*kentaurikw=s",
+    "opts": [
+      "-S",
+      "-n"
+    ],
+    "expected": "*kentaurikw=s\n<NL>N *kentauriko/s  adverbial\t\t\tos_h_on</NL><NL>N *kentaurikw/s,*kentauriko/s  masc acc pl\tdoric\t\tos_h_on</NL>\n"
+  },
+  {
+    "input": "kentaurikos",
+    "opts": [
+      "-S",
+      "-n"
+    ],
+    "expected": "kentaurikos\n<NL>N *kentauriko/s,*kentauriko/s  masc nom sg\t\t\tos_h_on</NL>\n"
   }
 ]


### PR DESCRIPTION
Some items in the dictionary are stored as capitalized (e.g. Κενταυρικός = *kentauriko/s). Currently the loose case matching mode (-S) works for Greek by removing capitalization from the search work and checking against the dictionary. That search fails if the dictionary word itself is capitalized. This PR adds an additional search mode where the search query is capitalized and then checked against the dictionary.

Some new tests in the fixture. Two existing test failures look unrelated to this PR.

The code is of course gnarly and I can't guarantee this change doesn't introduce any regressions. Happy to add additional tests to the fixture to try to confirm current desired behavior continues.